### PR TITLE
Fixed linux installation error

### DIFF
--- a/battery_linux.go
+++ b/battery_linux.go
@@ -1,4 +1,4 @@
-package main
+package battery
 
 import (
 	"bufio"


### PR DESCRIPTION
Fixed package name error due to repository configuration change.

when execute "go get" error happened in linux.
installation error is bellow

```
cmd/battery/main.go:8:2: found packages battery (battery.go) and main (battery_linux.go) in
```