### PR TITLE
Add an option to show elapsed time in discharging

### DIFF
--- a/battery.go
+++ b/battery.go
@@ -28,6 +28,7 @@ type Bar struct {
 	gaugeWidth  int
 	width       int
 	nowVal      int
+	elapsed     int
 	totalVal    int
 	charLen     int
 	format      string
@@ -37,6 +38,7 @@ type Bar struct {
 	ShowPercent bool
 	ShowCounter bool
 	Showthunder bool
+	ShowElapsed bool
 	EnableColor bool
 	EnableTmux  bool
 }
@@ -61,6 +63,7 @@ func New(total int) *Bar {
 		ShowPercent: true,
 		ShowCounter: true,
 		Showthunder: false,
+		ShowElapsed: false,
 		EnableColor: false,
 		EnableTmux:  true,
 	}
@@ -85,8 +88,9 @@ func (bar *Bar) SetWidth(width int) *Bar {
 	return bar
 }
 
-func (bar *Bar) Set(set int) *Bar {
-	bar.nowVal = set
+func (bar *Bar) Set(percent, elapsed int) *Bar {
+	bar.nowVal = percent
+	bar.elapsed = elapsed
 	return bar
 }
 
@@ -102,6 +106,10 @@ func (bar *Bar) writer() {
 	if bar.ShowCounter {
 		digit := digit(bar.totalVal)
 		bar.format += " %" + digit + "d/%" + digit + "d"
+	}
+
+	if bar.ShowElapsed {
+		bar.format += "%s"
 	}
 
 	if bar.nowVal <= bar.totalVal {
@@ -169,6 +177,14 @@ func (bar *Bar) write(frac float64) {
 	if bar.ShowCounter {
 		args = append(args, bar.nowVal)
 		args = append(args, bar.totalVal)
+	}
+
+	if bar.ShowElapsed {
+		if bar.elapsed > 0 {
+			args = append(args, fmt.Sprintf(" %d:%02d", bar.elapsed/60, bar.elapsed%60))
+		} else {
+			args = append(args, "")
+		}
 	}
 
 	if bar.EnableColor {

--- a/battery_linux.go
+++ b/battery_linux.go
@@ -32,7 +32,7 @@ func Info() (int, int, bool, error) {
 		case "POWER_SUPPLY_CHARGE_NOW":
 			now, _ = strconv.ParseFloat(tokens[1], 64)
 		case "POWER_SUPPLY_STATUS":
-			present = tokens[1] == "Full"
+			present = tokens[1] == "Charging"
 		case "POWER_SUPPLY_POWER_NOW":
 			powerNow, _ = strconv.ParseFloat(tokens[1], 64)
 		}

--- a/cmd/battery/main.go
+++ b/cmd/battery/main.go
@@ -20,13 +20,14 @@ type Options struct {
 	Help    bool `short:"h" long:"help"`
 	Tmux    bool `short:"t" long:"tmux"`
 	Has     bool `long:"has"`
+	Elapsed bool `short:"e" long:"elapsed"`
 	Version bool `short:"v" long:"version"`
 }
 
 func main() {
 	var opts Options
 	parseOptions(&opts, os.Args[1:])
-	percent, state, err := battery.Info()
+	percent, elapsed, state, err := battery.Info()
 	if err != nil {
 		fmt.Println(err.Error())
 		os.Exit(1)
@@ -37,12 +38,13 @@ func main() {
 	bar.ShowCounter = false
 	bar.EnableColor = true
 	bar.Showthunder = state
+	bar.ShowElapsed = opts.Elapsed
 
-	bar.Set(percent).Run()
+	bar.Set(percent, elapsed).Run()
 }
 
 func hasBattery() int {
-	if _, _, err := battery.Info(); err != nil {
+	if _, _, _, err := battery.Info(); err != nil {
 		return 1
 	}
 	return 0
@@ -92,6 +94,7 @@ func (opts Options) usage() []byte {
   -h,  --help        print usage and exit
   -v,  --version     display the version of battery and exit
   -t,  --tmux        display battery ascii art on tmux
+  -e,  --elapsed     display the elapsed time to charge / discharge
        --has         check to see if your device have the battery
 `)
 	return buf.Bytes()


### PR DESCRIPTION
I added an option `-e` to show elapsed time in discharging for all platforms.  You can see below if you execute `battery -e`.

<img width="109" alt="2018-04-30 18 51 02" src="https://user-images.githubusercontent.com/1239245/39427036-388223ce-4cbd-11e8-859a-5363cdac3452.png">

In addition, I fixed some features.

* 0722116 Fixed the condition to show thunder when charging.
* ded38a4 Enable to detect batteries in `BAT1`, `BAT2` and so on.